### PR TITLE
add: Poll utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from './utils/queue-processor';
 export * from './utils/unique-handling';
 export * from './utils/phone-formatter';
 export * from './utils/feature-toggles';
+export * from './utils/polling';
 export * from './models/marketplace-names';
 export * from './models/service-names';
 export * from './models/marketplace-region';

--- a/src/utils/__tests__/polling.ts
+++ b/src/utils/__tests__/polling.ts
@@ -1,0 +1,81 @@
+import { test } from '../../testing';
+import { poll } from '../polling';
+
+function createPollFn(returnDoneAfterMs = 2000) {
+    const threshold = Date.now() + returnDoneAfterMs;
+
+    return async () => ({
+        id: '123',
+        status: Date.now() >= threshold ? 'Done' : 'Pending',
+    });
+}
+
+test('polling for resource state using predicate resolves', async t => {
+    // arrange
+    const getMockResource = createPollFn(2800);
+
+    // act
+    const result = await poll(getMockResource, mockResource => mockResource.status === 'Done', {
+        pollIntervalInMs: 500,
+        pollTimeoutInMs: 3100,
+    });
+
+    // assert
+    t.deepEqual(result, { id: '123', status: 'Done' });
+});
+
+test('polling with low poll interval throws', async t => {
+    // arrange, act & assert
+    await t.throwsAsync(
+        () =>
+            poll(
+                () => null,
+                nullObject => !!nullObject,
+                { pollIntervalInMs: 499 },
+            ),
+        /interval/,
+    );
+});
+
+test('polling with low poll timeout throws', async t => {
+    // arrange, act & assert
+    await t.throwsAsync(
+        () =>
+            poll(
+                () => null,
+                nullObject => !!nullObject,
+                { pollTimeoutInMs: 1999 },
+            ),
+        /timeout/,
+    );
+});
+
+test('polling rejects if the underlying `pollFn` throws', async t => {
+    // arrange, act & assert
+    await t.throwsAsync(
+        () =>
+            poll(
+                () => {
+                    throw new Error("500: Couldn't fetch mock resource");
+                },
+                nullObject => !!nullObject,
+            ),
+        /fetch mock resource/,
+    );
+});
+
+test('polling for resource state times out', async t => {
+    // arrange
+    const getMockResource = createPollFn(60_000);
+
+    // act & assert
+    await t.throwsAsync(
+        () =>
+            poll(
+                () => getMockResource(),
+                mockResource => mockResource.status === 'Done',
+                { pollTimeoutInMs: 2000 },
+            ),
+        /Timed out/,
+    );
+});

--- a/src/utils/polling.ts
+++ b/src/utils/polling.ts
@@ -1,0 +1,37 @@
+export async function poll<T>(
+    pollFn: () => T | Promise<T>,
+    predicate: (value: T) => boolean,
+    { pollTimeoutInMs, pollIntervalInMs }: { pollTimeoutInMs?: number; pollIntervalInMs?: number } = {
+        pollTimeoutInMs: 10_000,
+        pollIntervalInMs: 500,
+    },
+): Promise<T> {
+    if (pollTimeoutInMs < 2000) throw new Error('Polling timeout has to be at least 2000 ms');
+    if (pollIntervalInMs < 500) throw new Error('Polling interval has to be at least 500 ms');
+
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            clearTimers(poller, timeout);
+            reject(new Error('Timed out.'));
+        }, pollTimeoutInMs);
+
+        const poller = setInterval(async () => {
+            try {
+                const pollResult = await pollFn();
+
+                if (!!predicate(pollResult)) {
+                    clearTimers(poller, timeout);
+                    resolve(pollResult);
+                }
+            } catch (e) {
+                clearTimers(poller, timeout);
+                reject(e);
+            }
+        }, pollIntervalInMs);
+    });
+}
+
+function clearTimers(poller: NodeJS.Timeout, timeout: NodeJS.Timeout) {
+    clearTimeout(timeout);
+    clearInterval(poller);
+}

--- a/src/utils/polling.ts
+++ b/src/utils/polling.ts
@@ -8,14 +8,14 @@ export async function poll<T>(
     if (pollTimeoutInMs < 2000) throw new Error('Polling timeout has to be at least 2000 ms');
     if (pollIntervalInMs < 500) throw new Error('Polling interval has to be at least 500 ms');
 
-    const clearTimers = (poller, timeout) => {
-        clearTimeout(timeout);
+    const clearTimers = (poller, timer) => {
+        clearTimeout(timer);
         clearInterval(poller);
     };
 
     return new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-            clearTimers(poller, timeout);
+        const timer = setTimeout(() => {
+            clearTimers(poller, timer);
             reject(new Error('Timed out.'));
         }, pollTimeoutInMs);
 
@@ -24,11 +24,11 @@ export async function poll<T>(
                 const pollResult = await pollFn();
 
                 if (!!predicate(pollResult)) {
-                    clearTimers(poller, timeout);
+                    clearTimers(poller, timer);
                     resolve(pollResult);
                 }
             } catch (e) {
-                clearTimers(poller, timeout);
+                clearTimers(poller, timer);
                 reject(e);
             }
         }, pollIntervalInMs);

--- a/src/utils/polling.ts
+++ b/src/utils/polling.ts
@@ -1,10 +1,9 @@
+type PollOptions = { pollTimeoutInMs?: number; pollIntervalInMs?: number };
+
 export async function poll<T>(
     pollFn: () => T | Promise<T>,
     predicate: (value: T) => boolean,
-    { pollTimeoutInMs, pollIntervalInMs }: { pollTimeoutInMs?: number; pollIntervalInMs?: number } = {
-        pollTimeoutInMs: 10_000,
-        pollIntervalInMs: 500,
-    },
+    { pollTimeoutInMs, pollIntervalInMs }: PollOptions = { pollTimeoutInMs: 10_000, pollIntervalInMs: 500 },
 ): Promise<T> {
     if (pollTimeoutInMs < 2000) throw new Error('Polling timeout has to be at least 2000 ms');
     if (pollIntervalInMs < 500) throw new Error('Polling interval has to be at least 500 ms');

--- a/src/utils/polling.ts
+++ b/src/utils/polling.ts
@@ -8,6 +8,11 @@ export async function poll<T>(
     if (pollTimeoutInMs < 2000) throw new Error('Polling timeout has to be at least 2000 ms');
     if (pollIntervalInMs < 500) throw new Error('Polling interval has to be at least 500 ms');
 
+    const clearTimers = (poller, timeout) => {
+        clearTimeout(timeout);
+        clearInterval(poller);
+    };
+
     return new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {
             clearTimers(poller, timeout);
@@ -28,9 +33,4 @@ export async function poll<T>(
             }
         }, pollIntervalInMs);
     });
-}
-
-function clearTimers(poller: NodeJS.Timeout, timeout: NodeJS.Timeout) {
-    clearTimeout(timeout);
-    clearInterval(poller);
 }


### PR DESCRIPTION
### Description

Adding a simple `poll` utility.

:warning: TODO Don't forget to **bump version after PR merge** 
 * `npm version major` (breaking change) or
 * `npm version minor` (feature) or
 * `npm version patch` (bugfix)

<br />

---

### Submitter

<details>
  <summary><strong>General</strong></summary>

- The PR addresses a **single thing** (at most ~300 LOC)
- The PR includes relevant integration, e2e or unit **tests** (unless dealing with emergency)
- The system **will continue to work** well for its users and for the developers after the PR is merged
- Related **documentation** was updated
- The PR contains some contextual description of the submitted feature (screenshot or video for UI changes)

</details>



### Reviewer

<details>
  <summary><strong>General</strong></summary>
  
  _Instead of seeking perfection, seek continuous improvement._ A PR that,
as a whole, improves the maintainability, readability, and understandability
of the system shouldn’t be delayed for days or weeks because it isn’t “perfect.”

  
  - The intention of the PR **is understood** (via description, UI screenshot or video, etc)
  - The code behaves as the author likely intended and the way the code behaves is good for its users.
  - The PR addresses a **single thing** (at most ~300 LOC)
  - The PR includes related integration, e2e or unit **tests** (unless dealing with emergency)
  - The PR **doesn't introduce a breaking change**. The system will continue to work well for its users and for the developers after the PR is merged
  - The PR is in a state where it definitely **improves the overall code health** of the system being worked on, _even if the PR isn’t perfect_
  - Related **documentation** was updated (incl. deprecation notice, etc)
</details>


<details>
  <summary><strong>Design</strong></summary>
  
  - Is now **a good time** to add this functionality?
  - Does it integrate well with the rest of your system?
  - Does this change belong in your codebase, or in a library?
  - Did the developer pick **good names** for everything?
  - Are the comments clear and useful, and mostly explain _why_ instead of what?
  - Does the changed code need refactoring? _(e.g. added few lines to function, but now it needs be broken up into smaller functions)_
</details>


<details>
  <summary><strong>Functionality & Complexity</strong></summary>
  
  - Is the code **too complex**? _(e.g. can’t be understood quickly by code readers; developers are likely to introduce bugs when they try to call or modify this code)_
  - Is the code over-engineered? Is there added **functionality that isn’t presently needed** by the system?
  - Are potential race conditions and deadlocks handled well?
</details>


<details>
  <summary><strong>Tests</strong></summary>
  
  _Tests are also code that has to be maintained._
Don’t accept complexity in tests just because they aren’t part of app in production.


  - Will the tests **actually fail** when the code is broken?
  - If the code changes beneath them, will they start producing **false positives**?
  - Does each test make simple and useful assertions?
  - Are the tests separated appropriately between different test methods?

</details>

<details>
  <summary><strong>Context</strong></summary>
  
  - Is this PR improving the code health of the system? Or is it making the whole system more complex, less tested, etc.? 

</details>

<details>
  <summary><strong>How-tos</strong></summary>
  
  - Comments that signify unimportant notes are prefixed with `Nit:` (short for _nitpicking_) or similar.
- Don't forget to offer encouragement and appreciation for good practices. It’s sometimes even more valuable, in terms of mentoring, to tell a developer what they did right than to tell them what they did wrong.


  - Be kind.
  - Explain your reasoning.
  - Balance giving explicit directions with just pointing out problems and letting the developer decide.
  - Encourage the submitter to simplify code or add code comments instead of just explaining the complexity to you.

</details>